### PR TITLE
Re-implement shrink/zoom

### DIFF
--- a/assets/ams.css
+++ b/assets/ams.css
@@ -36,7 +36,3 @@
   display:block;
   font-size: 15px;
 }
-/*HACK, cf. https://github.com/AmerMathSoc/AMS-Lens/issues/36*/
-.formula + .formula {
-  margin-top: -50px;
-}

--- a/assets/lib/mjLoader.js
+++ b/assets/lib/mjLoader.js
@@ -1,71 +1,72 @@
 window.MathJax = {
-    //  jax: ["input/TeX", "input/MathML","output/HTML-CSS"],
-    //  extensions: ["MathMenu.js","MathZoom.js", "CHTML-preview.js"],
     CommonHTML: {
-      // linebreaks: { automatic: true, width: "95% container" },
       EqnChunk: 100, EqnChunkFactor: 2.5, EqnChunkDelay: 10},
      "HTML-CSS": {
-      //  linebreaks: { automatic: true, width: "95% container" },
        EqnChunk: 100, EqnChunkFactor: 2.5, EqnChunkDelay: 10},
      SVG: {
-      //  linebreaks: { automatic: true, width: "95% container" },
        EqnChunk: 100, EqnChunkFactor: 2.5, EqnChunkDelay: 10},
      "fast-preview": {disabled: true},
      showProcessingMessages: false,
      messageStyle: "none",
      skipStartupTypeset: true,
      menuSettings: { zoom: "Click" },
-    //  extensions: ["[Contrib]/img.js"],
-    //  TeX: {extensions: ["AMSmath.js","AMSsymbols.js", "action.js"]},
      "displayAlign": "left",
-     "displayIndent": "40px", // TODO will often be article dependent. How do we implement this?
+     "displayIndent": "40px",
      AuthorInit: function () {
           // MathJax.Ajax.config.path["Contrib"] = "./assets/lib";
           var script = document.createElement('script');
           script.type = 'text/javascript';
           script.src = 'lens.js';
           document.getElementsByTagName('head')[0].appendChild(script);
-          //Reflow
-          // MathJax.Hub.Register.MessageHook("End Process", function (message) {
-          //   var timeout = false, // holder for timeout id
-          //   delay = 250; // delay after event is "complete" to run callback
-          //   var reflowMath = function() {
-          //     var dispFormulas = document.getElementsByClassName("formula");
-          //     if (dispFormulas){
-          //     for (var i=0; i<dispFormulas.length; i++){
-          //       var dispFormula = dispFormulas[i];
-          //       var child = dispFormula.getElementsByClassName("MathJax_Preview")[0].nextSibling.firstChild;
-          //       var isMultiline = MathJax.Hub.getAllJax(dispFormula)[0].root.isMultiline;
-          //       if(dispFormula.offsetWidth < child.offsetWidth || isMultiline){
-          //         MathJax.Hub.Queue(["Rerender", MathJax.Hub, dispFormula]);
-          //       }
-          //     }
-          //   }
-          //   };
-          //   window.addEventListener('resize', function() {
-          //       // clear the timeout
-          //     clearTimeout(timeout);
-          //     // start timing for event "completion"
-          //     timeout = setTimeout(reflowMath, delay);
-          //   });
-          // });
-          // shrink (leave zoom to MathJax)
           MathJax.Hub.Register.MessageHook("End Process", function (message) {
             //HACK clean up bad Lens nodes; cf. https://github.com/AmerMathSoc/AMS-Lens/issues/37
             var nodes = document.querySelectorAll(".paragraph > .content > .text > .content");
             for (var i = 0; i < nodes.length; i++){
-              if(nodes[i].innerHTML.trim().length === 0){
-                 var parent = nodes[i].parentNode.parentNode.parentNode;
-                 console.log(parent);
+              node = nodes[i];
+              if(node.innerHTML.trim().length === 0){
+                 var parent = node.parentNode.parentNode.parentNode;
                  parent.parentNode.removeChild(parent);
                }
+            }
+            // shrink with zoom from MathJax.
+            var timeout = false;
+            var delay = 250;
+            var shrinkMath = function() {
+              var dispFormulas = document.getElementsByClassName("formula");
+              if (dispFormulas){
+                // caculate relative size of indentation
+                var contentTest = document.getElementsByClassName("content")[0];
+                var nodesWidth = contentTest.offsetWidth;
+                var mathIndent = MathJax.Hub.config.displayIndent; //assuming indent is in px's
+                var mathIndentValue = mathIndent.substring(0,mathIndent.length - 2);
+                for (var i=0; i<dispFormulas.length; i++){
+                  var dispFormula = dispFormulas[i];
+                  var wrapper = dispFormula.getElementsByClassName("MathJax_Preview")[0].nextSibling;
+                  var child = wrapper.firstChild;
+                  wrapper.style.transformOrigin = "top left";
+                  var oldScale = child.style.transform;
+                  var newValue = Math.min(0.80*dispFormula.offsetWidth / child.offsetWidth,1.0).toFixed(2);
+                  var newScale = "scale(" + newValue + ")";
+                  if(!(newScale === oldScale)){
+                    wrapper.style.transform = newScale;
+                    wrapper.style["margin-left"]= Math.pow(newValue,4)*mathIndentValue + "px";
+                    var wrapperStyle = window.getComputedStyle(wrapper);
+                    var wrapperHeight = parseFloat(wrapperStyle.height);
+                    wrapper.style.height = "" + (wrapperHeight * newValue) + "px";
+                    if(newValue === "1.00"){
+                      wrapper.style.cursor = "";
+                    }
+                    else {
+                      wrapper.style.cursor = "zoom-in";
+                    }
+                  }
+
+                }
             }
             };
             shrinkMath();
             window.addEventListener('resize', function() {
-                // clear the timeout
               clearTimeout(timeout);
-              // start timing for event "completion"
               timeout = setTimeout(shrinkMath, delay);
             });
           });

--- a/assets/lib/mjLoader.js
+++ b/assets/lib/mjLoader.js
@@ -1,22 +1,55 @@
 window.MathJax = {
     //  jax: ["input/TeX", "input/MathML","output/HTML-CSS"],
     //  extensions: ["MathMenu.js","MathZoom.js", "CHTML-preview.js"],
-    CommonHTML: { linebreaks: { automatic: true }, EqnChunk: 100, EqnChunkFactor: 2.5, EqnChunkDelay: 10},
-     "HTML-CSS": { linebreaks: { automatic: true }, EqnChunk: 100, EqnChunkFactor: 2.5, EqnChunkDelay: 10},
-     SVG: { linebreaks: { automatic: true }, EqnChunk: 100, EqnChunkFactor: 2.5, EqnChunkDelay: 10},
+    CommonHTML: {
+      // linebreaks: { automatic: true, width: "95% container" },
+      EqnChunk: 100, EqnChunkFactor: 2.5, EqnChunkDelay: 10},
+     "HTML-CSS": {
+      //  linebreaks: { automatic: true, width: "95% container" },
+       EqnChunk: 100, EqnChunkFactor: 2.5, EqnChunkDelay: 10},
+     SVG: {
+      //  linebreaks: { automatic: true, width: "95% container" },
+       EqnChunk: 100, EqnChunkFactor: 2.5, EqnChunkDelay: 10},
      "fast-preview": {disabled: true},
      showProcessingMessages: false,
      messageStyle: "none",
+     skipStartupTypeset: true,
+     menuSettings: { zoom: "Click" },
     //  extensions: ["[Contrib]/img.js"],
     //  TeX: {extensions: ["AMSmath.js","AMSsymbols.js", "action.js"]},
      "displayAlign": "left",
-     "displayIndent": "5em", // TODO will often be article dependent. How do we implement this?
+     "displayIndent": "40px", // TODO will often be article dependent. How do we implement this?
      AuthorInit: function () {
           // MathJax.Ajax.config.path["Contrib"] = "./assets/lib";
           var script = document.createElement('script');
           script.type = 'text/javascript';
           script.src = 'lens.js';
           document.getElementsByTagName('head')[0].appendChild(script);
+          //Reflow
+          // MathJax.Hub.Register.MessageHook("End Process", function (message) {
+          //   var timeout = false, // holder for timeout id
+          //   delay = 250; // delay after event is "complete" to run callback
+          //   var reflowMath = function() {
+          //     var dispFormulas = document.getElementsByClassName("formula");
+          //     if (dispFormulas){
+          //     for (var i=0; i<dispFormulas.length; i++){
+          //       var dispFormula = dispFormulas[i];
+          //       var child = dispFormula.getElementsByClassName("MathJax_Preview")[0].nextSibling.firstChild;
+          //       var isMultiline = MathJax.Hub.getAllJax(dispFormula)[0].root.isMultiline;
+          //       if(dispFormula.offsetWidth < child.offsetWidth || isMultiline){
+          //         MathJax.Hub.Queue(["Rerender", MathJax.Hub, dispFormula]);
+          //       }
+          //     }
+          //   }
+          //   };
+          //   window.addEventListener('resize', function() {
+          //       // clear the timeout
+          //     clearTimeout(timeout);
+          //     // start timing for event "completion"
+          //     timeout = setTimeout(reflowMath, delay);
+          //   });
+          // });
+          // shrink (leave zoom to MathJax)
           MathJax.Hub.Register.MessageHook("End Process", function (message) {
             //HACK clean up bad Lens nodes; cf. https://github.com/AmerMathSoc/AMS-Lens/issues/37
             var nodes = document.querySelectorAll(".paragraph > .content > .text > .content");
@@ -27,6 +60,14 @@ window.MathJax = {
                  parent.parentNode.removeChild(parent);
                }
             }
+            };
+            shrinkMath();
+            window.addEventListener('resize', function() {
+                // clear the timeout
+              clearTimeout(timeout);
+              // start timing for event "completion"
+              timeout = setTimeout(shrinkMath, delay);
+            });
           });
       }
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "underscore": "1.8.x",
     "express": "3.3.x",
     "ejs": "*",
-    "lens": "elifesciences/lens.git#cc42407e5a2f01b87fe3504b5f264c842b5b9a6b"
+    "lens": "elifesciences/lens.git#fda704f12ed6128b0e310162a4134645857c756b"
   },
   "devDependencies": {
     "browserify": "substance/node-browserify#d3caeb6dcdaa97a258d099c7231a57f0f60ec876",


### PR DESCRIPTION
This adds a small MathJax pseudo-extension that implements a simpler shrink/zoom, re-using MathJax's zoom.

Fixes #22 (for now).
